### PR TITLE
Footer updates

### DIFF
--- a/app/scripts/services/messages.js
+++ b/app/scripts/services/messages.js
@@ -94,7 +94,7 @@ angular.module('cloudSlangWebsiteApp')
             contactPlaceholderMessage: 'Your Message',
 
             // about us
-            aboutUsByHp: 'Project CloudSlang by HP',
+            aboutUsByHp: 'Project CloudSlang by HPE',
             aboutUsWhoWeAreText: 'This project is being contributed to the open source community by HP Software engineers with the goal of leveraging the power of community to create the best-in-class orchestration technology.',
 
             // get started banner

--- a/app/scripts/services/messages.js
+++ b/app/scripts/services/messages.js
@@ -95,7 +95,7 @@ angular.module('cloudSlangWebsiteApp')
 
             // about us
             aboutUsByHp: 'Project CloudSlang by HPE',
-            aboutUsWhoWeAreText: 'This project is being contributed to the open source community by HP Software engineers with the goal of leveraging the power of community to create the best-in-class orchestration technology.',
+            aboutUsWhoWeAreText: 'This project is being contributed to the open source community by HPE Software engineers with the goal of leveraging the power of community to create the best-in-class orchestration technology.',
 
             // get started banner
             bannerTitle: 'Get Started',

--- a/app/views/footer.html
+++ b/app/views/footer.html
@@ -88,11 +88,11 @@
                     {{$root.messages.footerLicense}}
                 </a>
                 <i class="column-separator"></i>
-                <a ng-href="http://www8.hp.com/us/en/privacy/terms-of-use.html" analytics-on="click" analytics-event="footer terms of use" target="_blank">
+                <a ng-href="http://www8.hp.com/us/en/hpe/legal/terms-of-use.html" analytics-on="click" analytics-event="footer terms of use" target="_blank">
                     {{$root.messages.footerTerms}}
                 </a>
                 <i class="column-separator"></i>
-                <a ng-href="http://www8.hp.com/us/en/privacy/privacy.html" analytics-on="click" analytics-event="footer privacy" target="_blank">
+                <a ng-href="http://www8.hp.com/us/en/hpe/privacy/privacy.html" analytics-on="click" analytics-event="footer privacy" target="_blank">
                     {{$root.messages.footerPrivacy}}
                 </a>
             </div>


### PR DESCRIPTION
updates: 

1. about us: changed "HP" to "HPE"
2. footer: updated the privacy and the terms of use links to the new HPE links. 