### PR TITLE
Fix Mixed Content Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # CloudSlang.github.io
-CloudSlang website [http://cloudslang.io](http://cloudslang.io)
+CloudSlang website [https://cloudslang.io](https://cloudslang.io)
 
 [![Build Status](https://travis-ci.org/CloudSlang/CloudSlang.github.io.svg)](https://travis-ci.org/CloudSlang/CloudSlang.github.io)
 

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
     "name": "CloudSlang-site",
     "description": "this the CloudSlang project site",
-    "website": "http://cloudslang.io",
+    "website": "https://cloudslang.io",
     "keywords": [
         "CloudSlang slang"
     ],

--- a/app/scripts/controllers/docs.js
+++ b/app/scripts/controllers/docs.js
@@ -2,5 +2,5 @@
 
 angular.module('cloudSlangWebsiteApp')
     .controller('DocsCtrl', function () {
-        window.location.replace('http://cloudslang-docs.readthedocs.io/en/latest/');
+        window.location.replace('https://cloudslang-docs.readthedocs.io/en/latest/');
     });

--- a/app/views/community.html
+++ b/app/views/community.html
@@ -45,7 +45,7 @@
                 </div>
 
                 <div class="community-circle">
-                    <a ng-href="http://www.youtube.com/channel/UCunFZ98J-2slsd3NuP2WeBw" analytics-on="click" analytics-event="community youtube"
+                    <a ng-href="https://www.youtube.com/channel/UCunFZ98J-2slsd3NuP2WeBw" analytics-on="click" analytics-event="community youtube"
                        target="_blank" title="{{$root.messages.footerYoutube}}">
                         <i class="youtube social-icon fa fa-2x fa-youtube" style="color: white; margin-top: 3px"></i>
                     </a>
@@ -67,7 +67,7 @@
                 </a>
             </div>
             <div class="community-circle">
-                <a ng-href="http://cloudslang-docs.readthedocs.io/en/latest/developer/developer_contribution.html" analytics-on="click" analytics-event="community guide" target="_blank"
+                <a ng-href="https://cloudslang-docs.readthedocs.io/en/latest/developer/developer_contribution.html" analytics-on="click" analytics-event="community guide" target="_blank"
                    title="{{$root.messages.footerContribute}}">
                     <img style="margin-left: 3px" src="images/community/icon_guide.png">
                 </a>
@@ -94,7 +94,7 @@
                 </a>
             </div>
             <div class="community-circle">
-                <a ng-href="http://cloudslang-docs.readthedocs.io/en/latest/overview/section_tutorial.html" analytics-on="click" analytics-event="community tutorials" target="_blank"
+                <a ng-href="https://cloudslang-docs.readthedocs.io/en/latest/overview/section_tutorial.html" analytics-on="click" analytics-event="community tutorials" target="_blank"
                    title="{{$root.messages.footerTutorials}}">
                     <img src="images/community/icon_tutorial.png">
                 </a>

--- a/app/views/footer.html
+++ b/app/views/footer.html
@@ -4,7 +4,7 @@
             <div class="col-md-1"></div>
             <div class="col-md-2  text-center">
                 <div>
-                    <a ng-href="http://cloudslang-docs.readthedocs.io/en/latest/developer/developer_contribution.html" analytics-on="click" analytics-event="footer contribute" target="_blank" title="{{$root.messages.footerContribute}}">
+                    <a ng-href="https://cloudslang-docs.readthedocs.io/en/latest/developer/developer_contribution.html" analytics-on="click" analytics-event="footer contribute" target="_blank" title="{{$root.messages.footerContribute}}">
                         <span class="icon-text h4">{{$root.messages.footerContribute}}</span>
                     </a>
                 </div>
@@ -18,14 +18,14 @@
             </div>
             <div class="col-md-2  text-center footer-tutorials">
                 <div>
-                    <a ng-href="http://cloudslang-docs.readthedocs.io/en/latest/overview/section_tutorial.html" analytics-on="click" analytics-event="footer tutorials" target="_blank" title="{{$root.messages.footerTutorials}}">
+                    <a ng-href="https://cloudslang-docs.readthedocs.io/en/latest/overview/section_tutorial.html" analytics-on="click" analytics-event="footer tutorials" target="_blank" title="{{$root.messages.footerTutorials}}">
                         <span class="icon-text h4">{{$root.messages.footerTutorials}}</span>
                     </a>
                 </div>
             </div>
             <div class="col-md-2  text-center">
                 <div>
-                    <a ng-href="http://cloudslang-docs.readthedocs.io/en/latest/"  analytics-on="click" analytics-event="footer docs" target="_blank" title="{{$root.messages.footerDocs}}">
+                    <a ng-href="https://cloudslang-docs.readthedocs.io/en/latest/"  analytics-on="click" analytics-event="footer docs" target="_blank" title="{{$root.messages.footerDocs}}">
                         <span class="icon-text h4">{{$root.messages.footerDocs}}</span>
                     </a>
                 </div>
@@ -64,7 +64,7 @@
             </div>
             <div class="col-md-1 col-xs-2 text-center">
                 <div>
-                    <a ng-href="http://www.youtube.com/channel/UCunFZ98J-2slsd3NuP2WeBw" analytics-on="click" analytics-event="footer youtube" target="_blank" title="{{$root.messages.footerYoutube}}">
+                    <a ng-href="https://www.youtube.com/channel/UCunFZ98J-2slsd3NuP2WeBw" analytics-on="click" analytics-event="footer youtube" target="_blank" title="{{$root.messages.footerYoutube}}">
                         <i class="youtube social-icon fa fa-youtube"></i>
                     </a>
                 </div>
@@ -82,7 +82,7 @@
         <div class="row row-centered">
             <div class="col-md-11 col-xs-11 links">
                 <i class="column-separator"></i>
-                <a ng-href="http://www.apache.org/licenses/LICENSE-2.0.html" analytics-on="click" analytics-event="footer license" target="_blank">
+                <a ng-href="https://www.apache.org/licenses/LICENSE-2.0.html" analytics-on="click" analytics-event="footer license" target="_blank">
                     {{$root.messages.footerLicense}}
                 </a>
                 <i class="column-separator"></i>
@@ -97,6 +97,7 @@
                 <i class="column-separator"></i>
                 <a ng-href="https://www.microfocus.com/" analytics-on="click" analytics-event="footer microfocus" target="_blank">
                     © {{$root.year}} Micro Focus
+                </a>
             </div>
         </div>
     </div>
@@ -119,8 +120,7 @@
                         <div ng-include src="'views/subscription.html'"></div>
                     </div>
                     <br>
-                    <img class=" img-responsive pull-right popup-robot" src="http://i58.tinypic.com/ib995i.jpg">
-
+                    <img class="img-responsive pull-right popup-robot" src="images/gettingstarted/popup_robot.png">
                     <p class="h4 privacy">
                         <small>{{ $root.messages.emailPrivacy}}</small>
                     </p>

--- a/app/views/getstartedtodev.html
+++ b/app/views/getstartedtodev.html
@@ -29,7 +29,7 @@
             <p class="h5 get-started-desc">{{ $root.messages.getStartedToLearnText}}</p>
             <p class="h5 get-started-desc">{{ $root.messages.getStartedToLearnText1}}</p><br>
             <p class="h5 get-started-desc">
-                <a class="btn btn-default get-started-dev-fork-btn" href="http://cloudslang-docs.readthedocs.io/en/latest/" target="_blank">{{$root.messages.docsLink + "
+                <a class="btn btn-default get-started-dev-fork-btn" href="https://cloudslang-docs.readthedocs.io/en/latest/" target="_blank">{{$root.messages.docsLink + "
                     "}}
                 </a>
             </p>

--- a/app/views/getstartedtorun.html
+++ b/app/views/getstartedtorun.html
@@ -32,10 +32,10 @@
                    href="https://www.youtube.com/watch?v=9nYLXx5pRBw"
                    target="_blank">{{$root.messages.videoLink + " "}}
                 </a>
-                <a class="highlight-green" href="http://cloudslang-docs.readthedocs.io/en/latest/" target="_blank">{{$root.messages.docsLink + "
+                <a class="highlight-green" href="https://cloudslang-docs.readthedocs.io/en/latest/" target="_blank">{{$root.messages.docsLink + "
                     "}}
                 </a> {{ $root.messages.popUpBody2 + " "}}
-                <a class="highlight-green" href="http://cloudslang-docs.readthedocs.io/en/latest/overview/section_tutorial.html"
+                <a class="highlight-green" href="https://cloudslang-docs.readthedocs.io/en/latest/overview/section_tutorial.html"
                    target="_blank">{{$root.messages.tutorialLink }}
                 </a>.
             </p>

--- a/app/views/navbar.html
+++ b/app/views/navbar.html
@@ -22,7 +22,7 @@
             <li class="h5"><a data-toggle="modal" data-target="#footerModal" analytics-on="click" analytics-event="footer newsletter" title="{{$root.messages.navNewsletter}}">{{$root.messages.navNewsletter}}</a></li>
             <li class="h5"><a href="https://blog.cloudslang.io/" analytics-on="click" analytics-event="nav blog" target="_blank" >{{$root.messages.navBlogTitle}}</a></li>
             <li class="h5"><a href="#/community"  analytics-on="click" analytics-event="nav community" target="_top" >{{$root.messages.navCommunityTitle}} </a></li>
-            <li class="h5"><a href="http://cloudslang-docs.readthedocs.io/en/latest/"  analytics-on="click" analytics-event="nav docs" target="_blank">{{$root.messages.navDocumentationTitle}}</a></li>
+            <li class="h5"><a href="https://cloudslang-docs.readthedocs.io/en/latest/"  analytics-on="click" analytics-event="nav docs" target="_blank">{{$root.messages.navDocumentationTitle}}</a></li>
             <li class="h5"><a href="#/about"  analytics-on="click" analytics-event="nav about" class="h5"  target="_top">{{$root.messages.navAboutTitle}}</a></li>
             <li class="button-nav-position"><p class="navbar-btn">
                 <a href="#/getstarted#top" class="btn start-now-button-nav" role="button"  analytics-on="click" analytics-event="start now nav"><img src="images/button_icon.png" class="resize-nav"


### PR DESCRIPTION
Even though website was migrated to HTTPS, Chrome (and perhaps other browsers as well) marked it as "Not Secure". This happened due to mixed content references (resources loaded via HTTP). 
This PR refactors said resources. 
Additionally, there was an icon that was not only loaded via HTTP, but also from tinypic.com (which no longer exists). Changed that to a previously used local image.